### PR TITLE
fixed foreach to use kotlin extension, not the java one

### DIFF
--- a/library/src/main/java/ru/terrakok/scaremonger/dispatchers/DontRepeatDispatcher.kt
+++ b/library/src/main/java/ru/terrakok/scaremonger/dispatchers/DontRepeatDispatcher.kt
@@ -22,7 +22,7 @@ class DontRepeatDispatcher : ScaremongerDispatcher {
 
     override fun unsubscribe() {
         this.subscriber = null
-        callbackMap.forEach { _, list -> list.forEach { it.callback(false) } }
+        callbackMap.forEach { (_, list) -> list.forEach { it.callback(false) } }
         callbackMap.clear()
         disposableMap.clear()
     }


### PR DESCRIPTION
Java's  map.forEach requires android API >24.
Updated to use kotlin extension function to avoid this limitation